### PR TITLE
Add ERC20Token class (similar to old 0x utility class)

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -39,6 +39,7 @@ module.exports = {
                 children: [
                     "/",
                     "classes/dealerclient",
+                    "classes/erc20token",
                     "interfaces/dealerresponse",
                 ]
             },

--- a/docs/classes/dealerclient.md
+++ b/docs/classes/dealerclient.md
@@ -52,7 +52,7 @@ A simple client for the Zaidan dealer server.
 
 \+ **new DealerClient**(`dealerUri`: string, `web3Uri?`: string, `gasPrice`: number): *[DealerClient](dealerclient.md)*
 
-*Defined in [DealerClient.ts:70](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L70)*
+*Defined in [DealerClient.ts:70](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L70)*
 
 Instantiate a new DealerClient. Prior to use, `client.init()` should
 be called, which triggers a prompt for the user to allow MetaMask to
@@ -78,7 +78,7 @@ Name | Type | Default | Description |
 
 • **GAS_PRICE**: *BigNumber*
 
-*Defined in [DealerClient.ts:70](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L70)*
+*Defined in [DealerClient.ts:70](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L70)*
 
 Default gas price to use for allowance transactions.
 
@@ -88,7 +88,7 @@ ___
 
 • **coinbase**: *string*
 
-*Defined in [DealerClient.ts:58](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L58)*
+*Defined in [DealerClient.ts:58](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L58)*
 
 Stores the current user's coinbase address.
 
@@ -98,7 +98,7 @@ ___
 
 • **contractWrappers**: *ContractWrappers*
 
-*Defined in [DealerClient.ts:61](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L61)*
+*Defined in [DealerClient.ts:61](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L61)*
 
 Initialized contract wrappers for interacting with the 0x system.
 
@@ -108,7 +108,7 @@ ___
 
 • **initialized**: *boolean*
 
-*Defined in [DealerClient.ts:64](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L64)*
+*Defined in [DealerClient.ts:64](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L64)*
 
 Set to 'true' after a successful .init(), must be called before use.
 
@@ -118,7 +118,7 @@ ___
 
 • **isBrowser**: *boolean*
 
-*Defined in [DealerClient.ts:67](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L67)*
+*Defined in [DealerClient.ts:67](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L67)*
 
 Set to 'true' if browser environment is detected.
 
@@ -128,7 +128,7 @@ ___
 
 • **networkId**: *number*
 
-*Defined in [DealerClient.ts:55](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L55)*
+*Defined in [DealerClient.ts:55](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L55)*
 
 Stores the configured Ethereum network ID.
 
@@ -138,7 +138,7 @@ ___
 
 • **pairs**: *string[]*
 
-*Defined in [DealerClient.ts:38](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L38)*
+*Defined in [DealerClient.ts:38](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L38)*
 
 An array of the currently supported pairs (as expected by `getQuote`).
 
@@ -148,7 +148,7 @@ ___
 
 • **subProvider**: *MetamaskSubprovider*
 
-*Defined in [DealerClient.ts:52](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L52)*
+*Defined in [DealerClient.ts:52](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L52)*
 
 SubProvider instance used to interact with MetaMask.
 
@@ -158,7 +158,7 @@ ___
 
 • **tokens**: *object*
 
-*Defined in [DealerClient.ts:43](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L43)*
+*Defined in [DealerClient.ts:43](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L43)*
 
 Maps tokenTicker => address for looking up common tokens.
 
@@ -172,7 +172,7 @@ ___
 
 • **web3**: *Web3*
 
-*Defined in [DealerClient.ts:46](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L46)*
+*Defined in [DealerClient.ts:46](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L46)*
 
 Main Web3 instance for interacting with Ethereum.
 
@@ -182,7 +182,7 @@ ___
 
 • **web3Wrapper**: *Web3Wrapper*
 
-*Defined in [DealerClient.ts:49](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L49)*
+*Defined in [DealerClient.ts:49](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L49)*
 
 Provides additional convenience methods for interacting with web3.
 
@@ -192,7 +192,7 @@ ___
 
 ▪ **MAX_ALLOWANCE**: *BigNumber* =  new BigNumber(2).exponentiatedBy(256).minus(1)
 
-*Defined in [DealerClient.ts:24](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L24)*
+*Defined in [DealerClient.ts:24](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L24)*
 
 2^256 - 1 represents an effectively "unlimited" allowance
 
@@ -202,7 +202,7 @@ ___
 
 ▸ **fromWei**(`weiAmount`: string): *string*
 
-*Defined in [DealerClient.ts:439](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L439)*
+*Defined in [DealerClient.ts:439](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L439)*
 
 Convert a number of tokens, denominated in the smallest unit - "wei" - to
 "full" units, called "ether". One ether = 1*10^18 wei.
@@ -232,7 +232,7 @@ ___
 
 ▸ **getBalance**(`tokenTicker`: string): *Promise‹string›*
 
-*Defined in [DealerClient.ts:384](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L384)*
+*Defined in [DealerClient.ts:384](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L384)*
 
 Return the user's balance (in wei) of a specified supported token. Only
 supported tickers will work (see `client.tokens`).
@@ -262,7 +262,7 @@ ___
 
 ▸ **getEtherscanLink**(`txId`: string): *string*
 
-*Defined in [DealerClient.ts:473](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L473)*
+*Defined in [DealerClient.ts:473](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L473)*
 
 Returns the URL of the Etherscan status page for the specified TX ID.
 
@@ -284,7 +284,7 @@ ___
 
 ▸ **getQuote**(`size`: number, `symbol`: string, `side`: string): *Promise‹[DealerResponse](../interfaces/dealerresponse.md)›*
 
-*Defined in [DealerClient.ts:175](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L175)*
+*Defined in [DealerClient.ts:175](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L175)*
 
 Request orders from the Dealer server to sign. The response object
 contains a bid and ask order, both signed by the dealer server as the
@@ -327,7 +327,7 @@ ___
 
 ▸ **getSwapQuote**(`size`: number, `clientAsset`: string, `dealerAsset`: string): *Promise‹[DealerResponse](../interfaces/dealerresponse.md)›*
 
-*Defined in [DealerClient.ts:213](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L213)*
+*Defined in [DealerClient.ts:213](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L213)*
 
 An alternative interface for fetching a price quote using the concept of
 an asset "swap" as opposed to a conventional base/quote bid/ask interface.
@@ -369,7 +369,7 @@ ___
 
 ▸ **handleTrade**(`order`: SignedOrder, `quoteId`: string): *Promise‹string›*
 
-*Defined in [DealerClient.ts:259](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L259)*
+*Defined in [DealerClient.ts:259](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L259)*
 
 Sign a 0x `fillOrder` transaction message, and submit it back to the
 server for settlement. Signs a fill transaction for the entire specified
@@ -411,7 +411,7 @@ ___
 
 ▸ **hasAllowance**(`tokenTicker`: string): *Promise‹boolean›*
 
-*Defined in [DealerClient.ts:317](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L317)*
+*Defined in [DealerClient.ts:317](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L317)*
 
 Check if the user has set an allowance for the specified token. If the
 method returns `false`, allowance can be set with `client.setAllowance`.
@@ -444,7 +444,7 @@ ___
 
 ▸ **init**(): *Promise‹void›*
 
-*Defined in [DealerClient.ts:114](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L114)*
+*Defined in [DealerClient.ts:114](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L114)*
 
 Initialize a DealerClient instance. A call to `client.init()` will trigger
 a MetaMask pop-up prompting the user to sign in, or allow the site access.
@@ -461,7 +461,7 @@ ___
 
 ▸ **makeBigNumber**(`n`: number | string): *BigNumber*
 
-*Defined in [DealerClient.ts:418](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L418)*
+*Defined in [DealerClient.ts:418](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L418)*
 
 Turn a `string` or primitive `number` into a `BigNumber` for math reasons.
 
@@ -487,7 +487,7 @@ ___
 
 ▸ **setAllowance**(`tokenTicker`: string): *Promise‹TransactionReceiptWithDecodedLogs›*
 
-*Defined in [DealerClient.ts:356](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L356)*
+*Defined in [DealerClient.ts:356](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L356)*
 
 Set an unlimited proxy allowance for the 0x ERC20 Proxy contract for the
 specified token ticker.
@@ -522,7 +522,7 @@ ___
 
 ▸ **supportedTickers**(): *string[]*
 
-*Defined in [DealerClient.ts:496](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L496)*
+*Defined in [DealerClient.ts:496](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L496)*
 
 Return an array containing the list of supported token tickers.
 
@@ -541,7 +541,7 @@ ___
 
 ▸ **toWei**(`etherAmount`: string): *string*
 
-*Defined in [DealerClient.ts:460](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L460)*
+*Defined in [DealerClient.ts:460](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L460)*
 
 Convert a number of tokens (full units, called "ether") to "wei", the
 smallest denomination of most ERC-20 tokens with 18 decimals.
@@ -571,7 +571,7 @@ ___
 
 ▸ **waitForTransactionSuccessOrThrow**(`txId`: string): *Promise‹void›*
 
-*Defined in [DealerClient.ts:401](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/DealerClient.ts#L401)*
+*Defined in [DealerClient.ts:401](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/DealerClient.ts#L401)*
 
 Wait for a specific Ethereum transaction to be successfully mined.
 

--- a/docs/classes/erc20token.md
+++ b/docs/classes/erc20token.md
@@ -1,0 +1,191 @@
+[Zaidan dealer client](../README.md) › [Globals](../globals.md) › [ERC20Token](erc20token.md)
+
+# Class: ERC20Token
+
+
+Convenience class for interacting with multiple ERC-20 tokens through a single
+class, without needing to instantiate new contract instances for each token
+address used.
+
+Instances of the `ERC20Token` class provide methods for checking balances,
+allowances, and proxy allowances for the 0x ERC-20 asset proxy contract. It
+also provides methods for setting arbitrary or unlimited ERC-20 proxy allowances
+without needing to manually specify the asset proxy address.
+
+## Hierarchy
+
+* **ERC20Token**
+
+## Index
+
+### Constructors
+
+* [constructor](erc20token.md#constructor)
+
+### Properties
+
+* [UNLIMITED_ALLOWANCE](erc20token.md#static-unlimited_allowance)
+
+### Methods
+
+* [getAllowanceAsync](erc20token.md#getallowanceasync)
+* [getBalanceAsync](erc20token.md#getbalanceasync)
+* [getERC20ProxyAddressAsync](erc20token.md#geterc20proxyaddressasync)
+* [getNetworkIdAsync](erc20token.md#getnetworkidasync)
+* [getProxyAllowanceAsync](erc20token.md#getproxyallowanceasync)
+* [setProxyAllowanceAsync](erc20token.md#setproxyallowanceasync)
+* [setUnlimitedProxyAllowanceAsync](erc20token.md#setunlimitedproxyallowanceasync)
+
+## Constructors
+
+###  constructor
+
+\+ **new ERC20Token**(`provider`: SupportedProvider): *[ERC20Token](erc20token.md)*
+
+*Defined in [ERC20Token.ts:26](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/ERC20Token.ts#L26)*
+
+Create a new `ERC20Token` instance with a Web3 provider to access convenience
+methods for interacting with arbitrary ERC-20 tokens and the 0x ERC-20 asset
+proxy contract.
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`provider` | SupportedProvider | A supported Web3 JSONRPC provider  |
+
+**Returns:** *[ERC20Token](erc20token.md)*
+
+## Properties
+
+### `Static` UNLIMITED_ALLOWANCE
+
+▪ **UNLIMITED_ALLOWANCE**: *BigNumber* =  new BigNumber(2).exponentiatedBy(256).minus(1)
+
+*Defined in [ERC20Token.ts:17](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/ERC20Token.ts#L17)*
+
+## Methods
+
+###  getAllowanceAsync
+
+▸ **getAllowanceAsync**(`tokenAddress`: string, `userAddress`: string, `spenderAddress`: string): *Promise‹BigNumber›*
+
+*Defined in [ERC20Token.ts:63](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/ERC20Token.ts#L63)*
+
+Fetch user's ERC-20 allowance for a specific spender in base units (wei).
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`tokenAddress` | string | The ERC-20 token contract address. |
+`userAddress` | string | User's address to fetch allowance for. |
+`spenderAddress` | string | The spender address to fetch allowance for.  |
+
+**Returns:** *Promise‹BigNumber›*
+
+___
+
+###  getBalanceAsync
+
+▸ **getBalanceAsync**(`tokenAddress`: string, `userAddress`: string): *Promise‹BigNumber›*
+
+*Defined in [ERC20Token.ts:50](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/ERC20Token.ts#L50)*
+
+Fetch user's ERC-20 token balance in base units (wei).
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`tokenAddress` | string | The ERC-20 token contract address. |
+`userAddress` | string | User's address to fetch balance for.  |
+
+**Returns:** *Promise‹BigNumber›*
+
+___
+
+###  getERC20ProxyAddressAsync
+
+▸ **getERC20ProxyAddressAsync**(): *Promise‹string›*
+
+*Defined in [ERC20Token.ts:130](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/ERC20Token.ts#L130)*
+
+Fetch the 0x ERC-20 asset proxy address for the current network.
+
+**Returns:** *Promise‹string›*
+
+___
+
+###  getNetworkIdAsync
+
+▸ **getNetworkIdAsync**(): *Promise‹number›*
+
+*Defined in [ERC20Token.ts:122](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/ERC20Token.ts#L122)*
+
+Fetch the current detected networkId.
+
+**Returns:** *Promise‹number›*
+
+___
+
+###  getProxyAllowanceAsync
+
+▸ **getProxyAllowanceAsync**(`tokenAddress`: string, `userAddress`: string): *Promise‹BigNumber›*
+
+*Defined in [ERC20Token.ts:76](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/ERC20Token.ts#L76)*
+
+Fetch user's 0x ERC-20 proxy allowance for a given token in base units (wei).
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`tokenAddress` | string | The ERC-20 token contract address. |
+`userAddress` | string | User's address to fetch 0x ERC-20 proxy allowance for.  |
+
+**Returns:** *Promise‹BigNumber›*
+
+___
+
+###  setProxyAllowanceAsync
+
+▸ **setProxyAllowanceAsync**(`tokenAddress`: string, `allowance`: BigNumber, `txOptions?`: TxData): *Promise‹string›*
+
+*Defined in [ERC20Token.ts:91](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/ERC20Token.ts#L91)*
+
+Set user's 0x ERC-20 proxy allowance for a given token in base units (wei).
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`tokenAddress` | string | The ERC-20 token contract address. |
+`allowance` | BigNumber | The desired allowance (in wei) to set for the ERC-20 proxy. |
+`txOptions?` | TxData | Optional transaction options (gas price, etc). |
+
+**Returns:** *Promise‹string›*
+
+The resulting transaction hash.
+
+___
+
+###  setUnlimitedProxyAllowanceAsync
+
+▸ **setUnlimitedProxyAllowanceAsync**(`tokenAddress`: string, `txOptions?`: TxData): *Promise‹string›*
+
+*Defined in [ERC20Token.ts:109](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/ERC20Token.ts#L109)*
+
+Set an unlimited allowance for the 0x ERC-20 proxy allowance for a given
+token and user address.
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`tokenAddress` | string | The ERC-20 token contract address. |
+`txOptions?` | TxData | Optional transaction options (gas price, etc). |
+
+**Returns:** *Promise‹string›*
+
+The resulting transaction hash.

--- a/docs/globals.md
+++ b/docs/globals.md
@@ -8,6 +8,7 @@
 ### Classes
 
 * [DealerClient](classes/dealerclient.md)
+* [ERC20Token](classes/erc20token.md)
 
 ### Interfaces
 

--- a/docs/interfaces/dealerresponse.md
+++ b/docs/interfaces/dealerresponse.md
@@ -28,7 +28,7 @@ The parsed output of a GET /quote request.
 
 • **expiration**: *number*
 
-*Defined in [types.ts:10](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/types.ts#L10)*
+*Defined in [types.ts:10](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/types.ts#L10)*
 
 The UNIX timestamp at which this offer expires.
 
@@ -38,7 +38,7 @@ ___
 
 • **fee**: *number*
 
-*Defined in [types.ts:22](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/types.ts#L22)*
+*Defined in [types.ts:22](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/types.ts#L22)*
 
 The required fee from the dealer server.
 
@@ -48,7 +48,7 @@ ___
 
 • **id**: *string*
 
-*Defined in [types.ts:13](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/types.ts#L13)*
+*Defined in [types.ts:13](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/types.ts#L13)*
 
 The unique request ID that refers to this offer.
 
@@ -58,7 +58,7 @@ ___
 
 • **order**: *SignedOrder*
 
-*Defined in [types.ts:25](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/types.ts#L25)*
+*Defined in [types.ts:25](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/types.ts#L25)*
 
 The signed maker order from the dealer server.
 
@@ -68,7 +68,7 @@ ___
 
 • **price**: *number*
 
-*Defined in [types.ts:16](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/types.ts#L16)*
+*Defined in [types.ts:16](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/types.ts#L16)*
 
 The price and order data for the quote.
 
@@ -78,6 +78,6 @@ ___
 
 • **size**: *number*
 
-*Defined in [types.ts:19](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/4f06b1a/src/types.ts#L19)*
+*Defined in [types.ts:19](https://github.com/ParadigmFoundation/zaidan-dealer-client/blob/bdfe3d3/src/types.ts#L19)*
 
 The taker size, specified in the initial request.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "tsc",
     "test": "yarn start:snapshot && sleep 2 && yarn test:ci && yarn stop:snapshot",
-    "test:ci": "ts-mocha --exit test/spec_test.ts",
+    "test:ci": "ts-mocha --exit test/*_test.ts",
     "clean": "rm -rf node_modules dist",
     "compile:assets": "yarn build && webpack",
     "lint": "tslint -p .",
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "0x.js": "^7.0.1",
+    "@0x/contract-addresses": "^3.1.0",
     "@0x/subproviders": "^5.0.3",
     "@0x/web3-wrapper": "^6.0.12",
     "axios": "^0.19.0",

--- a/src/ERC20Token.ts
+++ b/src/ERC20Token.ts
@@ -1,0 +1,173 @@
+import { BigNumber, ERC20TokenContract, SupportedProvider, TxData } from "0x.js";
+import { ContractAddresses, getContractAddressesForNetworkOrThrow } from "@0x/contract-addresses";
+import { Web3Wrapper } from "@0x/web3-wrapper";
+import assert from "assert";
+
+/**
+ * Convenience class for interacting with multiple ERC-20 tokens through a single
+ * class, without needing to instantiate new contract instances for each token
+ * address used.
+ *
+ * Instances of the `ERC20Token` class provide methods for checking balances,
+ * allowances, and proxy allowances for the 0x ERC-20 asset proxy contract. It
+ * also provides methods for setting arbitrary or unlimited ERC-20 proxy allowances
+ * without needing to manually specify the asset proxy address.
+ */
+export class ERC20Token {
+    public static UNLIMITED_ALLOWANCE = new BigNumber(2).exponentiatedBy(256).minus(1);
+
+    private readonly _initializing: Promise<void>;
+    private readonly _tokenContracts: { [address: string]: ERC20TokenContract };
+    private readonly _provider: SupportedProvider;
+    private readonly _web3: Web3Wrapper;
+
+    private _networkId: number;
+    private _zrxAddresses: ContractAddresses;
+    private _erc20ProxyAddress: string;
+
+    /**
+     * Create a new `ERC20Token` instance with a Web3 provider to access convenience
+     * methods for interacting with arbitrary ERC-20 tokens and the 0x ERC-20 asset
+     * proxy contract.
+     *
+     * @param provider A supported Web3 JSONRPC provider
+     */
+    constructor(provider: SupportedProvider) {
+        this._tokenContracts = {};
+        this._provider = provider;
+        this._web3 = new Web3Wrapper(this._provider);
+
+        // resolves after loading network ID and contract addresses
+        this._initializing = this.initialize();
+    }
+
+    /**
+     * Fetch user's ERC-20 token balance in base units (wei).
+     *
+     * @param tokenAddress The ERC-20 token contract address.
+     * @param userAddress User's address to fetch balance for.
+     */
+    public async getBalanceAsync(tokenAddress: string, userAddress: string): Promise<BigNumber> {
+        const token = this.getTokenContract(tokenAddress);
+        const user = this.normalizeAddress(userAddress);
+        return token.balanceOf.callAsync(user);
+    }
+
+    /**
+     * Fetch user's ERC-20 allowance for a specific spender in base units (wei).
+     *
+     * @param tokenAddress The ERC-20 token contract address.
+     * @param userAddress User's address to fetch allowance for.
+     * @param spenderAddress The spender address to fetch allowance for.
+     */
+    public async getAllowanceAsync(tokenAddress: string, userAddress: string, spenderAddress: string): Promise<BigNumber> {
+        const user = this.normalizeAddress(userAddress);
+        const spender = this.normalizeAddress(spenderAddress);
+        const token = this.getTokenContract(tokenAddress);
+        return token.allowance.callAsync(user, spender);
+    }
+
+    /**
+     * Fetch user's 0x ERC-20 proxy allowance for a given token in base units (wei).
+     *
+     * @param tokenAddress The ERC-20 token contract address.
+     * @param userAddress User's address to fetch 0x ERC-20 proxy allowance for.
+     */
+    public async getProxyAllowanceAsync(tokenAddress: string, userAddress: string): Promise<BigNumber> {
+        await this._initializing;
+        const user = this.normalizeAddress(userAddress);
+        const token = this.getTokenContract(tokenAddress);
+        return token.allowance.callAsync(user, this._erc20ProxyAddress);
+    }
+
+    /**
+     * Set user's 0x ERC-20 proxy allowance for a given token in base units (wei).
+     *
+     * @param tokenAddress The ERC-20 token contract address.
+     * @param allowance The desired allowance (in wei) to set for the ERC-20 proxy.
+     * @param txOptions Optional transaction options (gas price, etc).
+     * @returns The resulting transaction hash.
+     */
+    public async setProxyAllowanceAsync(
+        tokenAddress: string,
+        allowance: BigNumber,
+        txOptions?: TxData,
+    ): Promise<string> {
+        await this._initializing;
+        const token = this.getTokenContract(tokenAddress);
+        return token.approve.validateAndSendTransactionAsync(this._erc20ProxyAddress, allowance, txOptions);
+    }
+
+    /**
+     * Set an unlimited allowance for the 0x ERC-20 proxy allowance for a given
+     * token and user address.
+     *
+     * @param tokenAddress The ERC-20 token contract address.
+     * @param txOptions Optional transaction options (gas price, etc).
+     * @returns The resulting transaction hash.
+     */
+    public async setUnlimitedProxyAllowanceAsync(tokenAddress: string, txOptions?: TxData): Promise<string> {
+        await this._initializing;
+        const token = this.getTokenContract(tokenAddress);
+        return token.approve.validateAndSendTransactionAsync(
+            this._erc20ProxyAddress,
+            ERC20Token.UNLIMITED_ALLOWANCE,
+            txOptions,
+        );
+    }
+
+    /**
+     * Fetch the current detected networkId.
+     */
+    public async getNetworkIdAsync(): Promise<number> {
+        await this._initializing;
+        return this._networkId;
+    }
+
+    /**
+     * Fetch the 0x ERC-20 asset proxy address for the current network.
+     */
+    public async getERC20ProxyAddressAsync(): Promise<string> {
+        await this._initializing;
+        return this._erc20ProxyAddress;
+    }
+
+    /**
+     * Load network ID from provider and configured Ox contract addresses.
+     */
+    private async initialize(): Promise<void> {
+        this._networkId = await this._web3.getNetworkIdAsync();
+        this._zrxAddresses = getContractAddressesForNetworkOrThrow(this._networkId);
+        this._erc20ProxyAddress = this._zrxAddresses.erc20Proxy;
+    }
+
+    /**
+     * Return an initialized contract wrapper instance from cache or create a
+     * new one if not yet stored for the given address.
+     *
+     * @param _address Token address to get contract instance for.
+     */
+    private getTokenContract(_address: string): ERC20TokenContract {
+        const address = this.normalizeAddress(_address);
+        let contract = this._tokenContracts[address];
+
+        if (contract) {
+            assert.strictEqual(address, contract.address, "ERC20Token: address mismatch");
+            return contract;
+        } else {
+            contract = new ERC20TokenContract(address, this._provider);
+            this._tokenContracts[address] = contract;
+        }
+        return contract;
+    }
+
+    /**
+     * Validate address (checksummed or not) and return un-checksummed lowercase.
+     *
+     * @param address Token's contract address.
+     */
+    private normalizeAddress(address: string): string {
+        assert(/^0x[a-fA-F0-9]{40}$/.test(address), "ERC20Token: invalid Ethereum address");
+        return address.toString();
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { ERC20Token } from "./ERC20Token";
 export { DealerClient } from "./DealerClient";
 export { DealerResponse } from "./types";
 export { SignedOrder } from "0x.js";

--- a/test/helpers/mockDealer.ts
+++ b/test/helpers/mockDealer.ts
@@ -11,7 +11,7 @@ import express from "express";
 import uuid from "uuid/v4";
 import Web3 from "web3";
 
-import { DealerResponse } from "../src/types";
+import { DealerResponse } from "../../src/types";
 
 const {
     WEB3_URL = "http://localhost:8545",

--- a/test/spec_test.ts
+++ b/test/spec_test.ts
@@ -7,7 +7,7 @@ import Web3 from "web3";
 import { DealerClient } from "../src/DealerClient";
 
 // start mocking server
-import { app } from "./mockDealer";
+import { app } from "./helpers/mockDealer";
 
 const {
     WEB3_URL = "http://localhost:8545",

--- a/test/token_test.ts
+++ b/test/token_test.ts
@@ -1,0 +1,123 @@
+import { BigNumber, ContractWrappers } from "0x.js";
+import { DummyERC20TokenContract } from "@0x/abi-gen-wrappers";
+import assert, { doesNotReject } from "assert";
+import { Server } from "http";
+import Web3 from "web3";
+
+import { ERC20Token } from "../src";
+
+const {
+    WEB3_URL = "http://localhost:8545",
+
+    // defaults are 0x snapshot dummy ERC-20 tokens (format "TICKER:ADDRESS")
+    DUMMY_TOKEN_A = "TKA:0x34d402f14d58e001d8efbe6585051bf9706aa064",
+    DUMMY_TOKEN_B = "TKB:0x25b8fe1de9daf8ba351890744ff28cf7dfa8f5e3",
+
+    TEST_ACCOUNT_INDEX = "6",
+    MINT_AMOUNT_A = "100",
+    MINT_AMOUNT_B = "200",
+} = process.env;
+
+describe("ERC20Token helper class tests", function (): void {
+    this.timeout("2m");
+
+    const ZERO = new BigNumber(0);
+
+    // unlimited ERC-20 allowance (2**256 - 1)
+    const MAX_ALLOWANCE = new BigNumber(2).exponentiatedBy(256).minus(1);
+
+    const mintAmountA = new BigNumber(Web3.utils.toWei(MINT_AMOUNT_A));
+    const mintAmountB = new BigNumber(Web3.utils.toWei(MINT_AMOUNT_B));
+
+    let web3: Web3;
+    let erc20: ERC20Token;
+
+    let address: string;
+
+    let contractWrappers: ContractWrappers;
+    let erc20ProxyAddress: string;
+    let networkId: number;
+    let accounts: string[];
+
+    let tokenAAddress: string;
+    let tokenBAddress: string;
+    let tokenA: DummyERC20TokenContract;
+    let tokenB: DummyERC20TokenContract;
+
+    this.beforeAll("setup web3, 0x contract wrappers, and test accounts", async function (): Promise<void> {
+        web3 = new Web3(WEB3_URL);
+
+        networkId = await web3.eth.net.getId();
+        accounts = await web3.eth.getAccounts();
+
+        contractWrappers = new ContractWrappers(web3.currentProvider, { networkId });
+        erc20ProxyAddress = contractWrappers.erc20Proxy.address;
+
+        address = accounts[parseInt(TEST_ACCOUNT_INDEX)];
+
+        erc20 = new ERC20Token(web3.currentProvider);
+    });
+
+    this.beforeAll("setup dummy tokens", async function (): Promise<void> {
+        tokenAAddress = DUMMY_TOKEN_A.split(":")[1];
+        tokenBAddress = DUMMY_TOKEN_B.split(":")[1];
+
+        tokenA = new DummyERC20TokenContract(tokenAAddress, web3.currentProvider);
+        tokenB = new DummyERC20TokenContract(tokenBAddress, web3.currentProvider);
+
+    });
+
+    it("should have the correct erc20 proxy address", async function (): Promise<void> {
+        const loadedAddress = await erc20.getERC20ProxyAddressAsync();
+        assert.strictEqual(loadedAddress, erc20ProxyAddress, "asset proxy addresses should match");
+    });
+
+    it("should have the correct network ID", async function (): Promise<void> {
+        const loadedId = await erc20.getNetworkIdAsync();
+        assert.strictEqual(loadedId, networkId, "network ID's should match");
+    });
+
+    it("should correctly fetch balances before mint", async function (): Promise<void> {
+        const balanceA = await erc20.getBalanceAsync(tokenAAddress, address);
+        const balanceB = await erc20.getBalanceAsync(tokenBAddress, address);
+
+        assert.strictEqual(balanceA.toString(), ZERO.toString(), "balance should be 0 before mint");
+        assert.strictEqual(balanceB.toString(), ZERO.toString(), "balance should be 0 before mint");
+
+        // mint tokens for next assertions
+        await tokenA.mint.sendTransactionAsync(mintAmountA, { from: address });
+        await tokenB.mint.sendTransactionAsync(mintAmountB, { from: address });
+    });
+
+    it("should correctly fetch balances after mint", async function (): Promise<void> {
+        const balanceA = await erc20.getBalanceAsync(tokenAAddress, address);
+        const balanceB = await erc20.getBalanceAsync(tokenBAddress, address);
+
+        assert.strictEqual(balanceA.toString(), mintAmountA.toString(), "balance A should match expected mint amount");
+        assert.strictEqual(balanceB.toString(), mintAmountB.toString(), "balance B should match expected mint amount");
+    });
+
+    it("should correctly show no allowances before being set", async function (): Promise<void> {
+        const allowanceA = await erc20.getProxyAllowanceAsync(tokenAAddress, address);
+        const allowanceB = await erc20.getProxyAllowanceAsync(tokenBAddress, address);
+
+        assert.strictEqual(allowanceA.toString(), ZERO.toString(), "should have no proxy allowance for token A");
+        assert.strictEqual(allowanceB.toString(), ZERO.toString(), "should have no proxy allowance for token B");
+    });
+
+    it("should set unlimited ERC-20 proxy allowances without error", async function (): Promise<void> {
+        const txIdA = await erc20.setUnlimitedProxyAllowanceAsync(tokenAAddress, { from: address });
+        const txIdB = await erc20.setUnlimitedProxyAllowanceAsync(tokenBAddress, { from: address });
+
+        assert(/^0x[a-fA-F0-9]{64}$/.test(txIdA), "txIdA should be a valid transaction hash");
+        assert(/^0x[a-fA-F0-9]{64}$/.test(txIdB), "txIdB should be a valid transaction hash");
+    });
+
+    it("should correctly show unlimited allowances after being set", async function (): Promise<void> {
+        const allowanceA = await erc20.getProxyAllowanceAsync(tokenAAddress, address);
+        const allowanceB = await erc20.getProxyAllowanceAsync(tokenBAddress, address);
+
+        assert.strictEqual(allowanceA.toString(), MAX_ALLOWANCE.toString(), "should have max proxy allowance for token A");
+        assert.strictEqual(allowanceB.toString(), MAX_ALLOWANCE.toString(), "should have max proxy allowance for token B");
+    });
+});


### PR DESCRIPTION
## Overview

Adding a custom ERC-20 token abstraction. A similar class used to be exposed by the 0x.js `ContractWrappers` class, but was removed in `@0x/contract-wrappers` v11