### PR TITLE
erc20: missing toLowerCase in normalizeAddress

### DIFF
--- a/src/ERC20Token.ts
+++ b/src/ERC20Token.ts
@@ -247,6 +247,6 @@ export class ERC20Token {
      */
     private normalizeAddress(address: string): string {
         assert(/^0x[a-fA-F0-9]{40}$/.test(address), "ERC20Token: invalid Ethereum address");
-        return address.toString();
+        return address.toLowerCase();
     }
 }


### PR DESCRIPTION
## Overview

The method `normalizeAddress` was not doing what it says, now it is.